### PR TITLE
Adding lazy.nvim install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Plugin 'hardhackerlabs/theme-vim', { 'name': 'hardhacker' }
 Plug 'hardhackerlabs/theme-vim', { 'as': 'hardhacker' }
 ```
 
+### Using Lazy.nvim (for neovim user)
+If you're using neovim, you can use [lazy.nvim](https://github.com/folke/lazy.nvim) to install too
+```lua
+-- init.lua:
+  {
+    'hardhackerlabs/theme-vim',
+    config = function()
+      vim.cmd.colorscheme 'hardhacker'
+    end,
+  },
+```
 ## Setup
 
 Add the following configuration to the `~/.vimrc` or `~/.config/nvim/init.vim` file, then restart Vim or Neovim

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plug 'hardhackerlabs/theme-vim', { 'as': 'hardhacker' }
 ```
 
 ### Using Lazy.nvim (for neovim user)
-If you're using neovim, you can use [lazy.nvim](https://github.com/folke/lazy.nvim) to install too
+If you're using neovim, you can use [lazy.nvim](https://github.com/folke/lazy.nvim) too
 ```lua
 -- init.lua:
   {


### PR DESCRIPTION
Hi, I found the theme can be install from `lazy.nvim` easily, so I'd like to propose a change for neovim with lazy.nvim user.